### PR TITLE
Fix crash when tasks file is empty

### DIFF
--- a/task_tracker/models.py
+++ b/task_tracker/models.py
@@ -24,8 +24,10 @@ class Task:
 def load_tasks():
     if not TASKS_FILE.exists():
         return []
-    with open(TASKS_FILE) as f:
-        return [Task.from_dict(t) for t in json.load(f)]
+    content = TASKS_FILE.read_text().strip()
+    if not content:
+        return []
+    return [Task.from_dict(t) for t in json.loads(content)]
 
 
 def save_tasks(tasks):


### PR DESCRIPTION
Fixes #2

`load_tasks()` now handles the case where the tasks JSON file exists but is empty, instead of letting `json.load()` raise a `JSONDecodeError`.