### PR TITLE
Add due date support

### DIFF
--- a/task_tracker/__main__.py
+++ b/task_tracker/__main__.py
@@ -6,15 +6,23 @@ from .utils import format_task, next_id
 
 
 def cmd_add(args):
+    due = None
+    if "--due" in args:
+        idx = args.index("--due")
+        due = args[idx + 1]
+        args = args[:idx] + args[idx + 2:]
     title = " ".join(args)
     if not title:
         print("Error: task title required")
         sys.exit(1)
     tasks = load_tasks()
-    task = Task(id=next_id(tasks), title=title)
+    task = Task(id=next_id(tasks), title=title, due=due)
     tasks.append(task)
     save_tasks(tasks)
-    print(f"Added task {task.id}: {task.title}")
+    msg = f"Added task {task.id}: {task.title}"
+    if task.due:
+        msg += f" (due {task.due})"
+    print(msg)
 
 
 def cmd_list(args):

--- a/task_tracker/models.py
+++ b/task_tracker/models.py
@@ -12,6 +12,7 @@ class Task:
     id: int
     title: str
     completed: bool = False
+    due: str | None = None
 
     def to_dict(self):
         return asdict(self)

--- a/task_tracker/utils.py
+++ b/task_tracker/utils.py
@@ -3,7 +3,10 @@
 
 def format_task(task):
     status = "x" if task.completed else " "
-    return f"[{status}] {task.id}: {task.title}"
+    line = f"[{status}] {task.id}: {task.title}"
+    if task.due:
+        line += f"  (due {task.due})"
+    return line
 
 
 def next_id(tasks):


### PR DESCRIPTION
Closes #1

Adds an optional `--due` flag to the `add` command and displays due dates in the task list.

### Usage
```bash
python -m task_tracker add "Buy groceries" --due 2025-03-01
python -m task_tracker list
# [ ] 1: Buy groceries  (due 2025-03-01)
```